### PR TITLE
Link to local images and hard-wrap README text

### DIFF
--- a/kudos_csh/README.md
+++ b/kudos_csh/README.md
@@ -1,9 +1,11 @@
-Kudos ROS Package
-=======
-This package provides SLAM functionality to kudos through the use of a neatoXV Lidar.
+# Kudos ROS Package
+
+This package provides SLAM functionality to kudos through the use of a neatoXV
+Lidar.
 
 ROS Package Dependencies
 ------------------------
+
 - The following ROS packages are needed to use kudos\_csh:
 - tf
 - hector\_mapping
@@ -11,8 +13,13 @@ ROS Package Dependencies
 - xv\_11\_laser\_driver
 
 ### Initial Mapping Results
-Kudos was outfitter with Trevor Sherrard's ([@SherrardTr4129](https://github.com/sherrardTr4129)) neatoXV LiDAR. The LiDAR was tethered to an laptoprunning this ROS package. As the Robot was driven around floor a map was created as the robot localized its position and pose. Some screenshots of the map in Rviz can be seen below.
 
-![CSH Map1](https://www.csh.rit.edu/~sherrardtr/CSH_Map_1.png)
+Kudos was outfitter with Trevor Sherrard's
+([@SherrardTr4129](https://github.com/sherrardTr4129)) neatoXV LiDAR.
+The LiDAR was tethered to an laptoprunning this ROS package.
+As the Robot was driven around floor a map was created as the robot localized
+its position and pose. Some screenshots of the map in Rviz can be seen below.
 
-![CSH Map2](https://www.csh.rit.edu/~sherrardtr/CSH_Map_2.png)
+![CSH Map1](images/CSH_Map_1.png)
+
+![CSH Map2](images/CSH_Map_2.png)


### PR DESCRIPTION
The big change here is just to link to local images in `kudos_csh/images/` so that assets will stay up-to-date. The 80-col wrap is just for better plaintext readability.