### PR TITLE
Add support for off-boarding SLAM algorithm 

### DIFF
--- a/kudos_csh/launch/hector_neato_bringup.launch
+++ b/kudos_csh/launch/hector_neato_bringup.launch
@@ -1,13 +1,6 @@
 <?xml version="1.0"?>
-
 <launch>
-  <node pkg="xv_11_laser_driver" type="neato_laser_publisher" name="xv_11_node">
-    <param name="port" value="/dev/ttyACM0"/>
-    <param name="firmware_version" value="2"/>
-    <param name="frame_id" value="laser"/>
-  </node>
   <node pkg="tf" type="static_transform_publisher" name="base_frame_2_laser" args="0 0 0 0 0 0 /base_frame /laser 100"/> 
-  <node pkg="rviz" type="rviz" name="rviz" args="-d rviz_cfg.rviz"/>
   <include file="$(find kudos_csh)/launch/default_mapping.launch"/> 
   <include file="$(find hector_geotiff)/launch/geotiff_mapper.launch"/>
 </launch>

--- a/kudos_csh/launch/x11_neato_bringup.launch
+++ b/kudos_csh/launch/x11_neato_bringup.launch
@@ -1,0 +1,7 @@
+<launch>
+  <node pkg="xv_11_laser_driver" type="neato_laser_publisher" name="xv_11_node">
+    <param name="port" value="/dev/ttyACM0"/>
+    <param name="firmware_version" value="2"/>
+    <param name="frame_id" value="laser"/>
+  </node>
+</launch>


### PR DESCRIPTION
Moved the Neato XV Lidar bringup into separate launch file for use on robot. SLAM bringup is now isolated for use on VM.